### PR TITLE
repair a problem with adding columns to dataframes with no rows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ compiled/
 doc/
 .DS_Store
 *.bak
+*~

--- a/table.rkt
+++ b/table.rkt
@@ -112,7 +112,10 @@ All rights reserved.
                (list (cons as (column-data col)))))
 
       ; create a new data vector using the existing index
-      (let ([v (make-vector (+ (vector-argmax identity (table-index df)) 1) #f)])
+      (let* ([vec-len
+              (cond [(= (vector-length (table-index df)) 0) 0]
+                    [else (add1 (vector-argmax identity (table-index df)))])]
+             [v (make-vector vec-len #f)])
         (for ([i (table-index df)] [x seq])
           (vector-set! v i x))
 

--- a/test/test.rkt
+++ b/test/test.rkt
@@ -281,3 +281,22 @@ All rights reserved.
   (test-case "Writing JSON lines"
              (check-write/read (λ (port) (table-write/json df port #:lines? #t))
                                (λ (port) (table-read/json port #:lines? #t)))))
+
+
+;; --- misc other tests?
+
+
+(check-not-exn
+ (λ ()
+   (table-with-column
+    (table-with-column empty-table '() #:as 'a)
+    '() #:as 'b)))
+
+(check-equal?
+ (sequence->list
+  (table-column
+   (table-with-column
+    (table-with-column empty-table '() #:as 'a)
+    '() #:as 'b)
+   'b))
+ '())


### PR DESCRIPTION
The existing code appears to have a bug that prevents adding a column to a table with columns but no rows. Specifically, it uses argmax on the index vector to determine the size of the new vector, but for tables with columns but no rows, this index vector is empty, and argmax signals an error. To solve this, I special-case the empty vector and return zero as the length of the new vector.