### PR TITLE
use runtime-path to load files

### DIFF
--- a/examples/sample.rkt
+++ b/examples/sample.rkt
@@ -11,9 +11,12 @@ All rights reserved.
 
 (require plot)
 (require tabular-asa)
+(require racket/runtime-path)
+
+(define-runtime-path here ".")
 
 ; load a CSV file into a dataframe
-(define books (call-with-input-file "books.csv" table-read/csv))
+(define books (call-with-input-file (build-path here "books.csv") table-read/csv))
 
 ; keep only the genre and title columns
 (define genre-title (table-cut books '(Genre Title)))

--- a/test/test.rkt
+++ b/test/test.rkt
@@ -9,7 +9,12 @@ All rights reserved.
 
 |#
 
-(require rackunit)
+(require rackunit
+         racket/runtime-path)
+
+;; ----------------------------------------------------
+
+(define-runtime-path here ".")
 
 ;; ----------------------------------------------------
 
@@ -36,7 +41,7 @@ All rights reserved.
 
 ;; ----------------------------------------------------
 
-(define heroes (call-with-input-file "heroes.csv" table-read/csv))
+(define heroes (call-with-input-file (build-path here "heroes.csv") table-read/csv))
 
 ;; ----------------------------------------------------
 
@@ -53,7 +58,8 @@ All rights reserved.
 
 ;; ----------------------------------------------------
 
-(define hero-creators (call-with-input-file "creators.json" table-read/json))
+(define hero-creators (call-with-input-file (build-path here "creators.json")
+                        table-read/json))
 
 ;; ----------------------------------------------------
 


### PR DESCRIPTION
This change makes references to files such as heroes.csv relative to the source file, not relative to the current working directory. It's also necessary to make e.g. coverage testing with `raco cover` work correctly.