### PR TITLE
Added reading CSV 'readers' and fix table-preview printing.

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,7 +1,7 @@
 #lang info
 
 (define collection "tabular-asa")
-(define version "0.3.3")
+(define version "0.4.0")
 (define pkg-authors '("massung@gmail.com"))
 (define pkg-desc "A fast, efficient, immutable, dataframes implementation")
 (define deps '("base" "rackunit-lib" "scribble-lib" "racket-doc" "scribble-doc" "csv-reading"))

--- a/main.rkt
+++ b/main.rkt
@@ -64,6 +64,7 @@ All rights reserved.
  ; table
  (struct-out table)
  empty-table
+ table-preview-shape
  table-preview
  table-length
  table-shape

--- a/main.rkt
+++ b/main.rkt
@@ -128,17 +128,11 @@ All rights reserved.
  for/table
 
  ; print
+ format-table
  display-table
  print-table
- write-table
 
  ; write
  table-write/csv
  table-write/json
  table-write/string)
-
-;; ----------------------------------------------------
-
-(table-preview (let ([old-preview (table-preview)])
-                 (λ (df port mode)
-                   (display-table df port))))

--- a/print.rkt
+++ b/print.rkt
@@ -15,9 +15,9 @@ All rights reserved.
 ;; ----------------------------------------------------
 
 (provide pretty-print-rows
+         format-table
          print-table
-         display-table
-         write-table)
+         display-table)
 
 ;; ----------------------------------------------------
 
@@ -63,11 +63,17 @@ All rights reserved.
 
 ;; ----------------------------------------------------
 
-(define (write-table df
-                     [port (current-output-port)]
-                     [repr ~a]
-                     #:keep-index? [keep-index #t])
-  (let* ([index-format (column-formatter '|| (index-preview df) repr)]
+(define (format-table-shape df port)
+  (let-values ([(rows cols) (table-shape df)])
+    (fprintf port "[~a rows x ~a cols]" rows cols)))
+
+;; ----------------------------------------------------
+
+(define (format-table df port mode #:keep-index? [keep-index #t])
+  (let* ([repr (if mode ~v ~a)]
+
+         ; how to display the index column
+         [index-format (column-formatter '|| (index-preview df) repr)]
 
          ; formatters for each column
          [column-formats (for/list ([k (table-header df)])
@@ -93,19 +99,14 @@ All rights reserved.
 
     ; output the shape of the table
     (newline port)
-    (fprintf port "[~a rows x ~a cols]"
-             (table-length df)
-             (length (table-data df)))
-
-    ; done
-    (newline port)))
+    (format-table-shape df port)))
 
 ;; ----------------------------------------------------
 
-(define (display-table df [port (current-output-port)] #:keep-index? [keep-index #t])
-  (write-table df port ~a #:keep-index? keep-index))
+(define (display-table df [port (current-output-port)] [mode #f] #:keep-index? [keep-index #t])
+  (format-table df port #f #:keep-index? keep-index))
 
 ;; ----------------------------------------------------
 
-(define (print-table df [port (current-output-port)] #:keep-index? [keep-index #t])
-  (write-table df port ~v #:keep-index? keep-index))
+(define (print-table df [port (current-output-port)] [mode #t] #:keep-index? [keep-index #t])
+  (format-table df port #t #:keep-index? keep-index))

--- a/print.rkt
+++ b/print.rkt
@@ -103,10 +103,10 @@ All rights reserved.
 
 ;; ----------------------------------------------------
 
-(define (display-table df [port (current-output-port)] [mode #f] #:keep-index? [keep-index #t])
+(define (display-table df [port (current-output-port)] #:keep-index? [keep-index #t])
   (format-table df port #f #:keep-index? keep-index))
 
 ;; ----------------------------------------------------
 
-(define (print-table df [port (current-output-port)] [mode #t] #:keep-index? [keep-index #t])
+(define (print-table df [port (current-output-port)] #:keep-index? [keep-index #t])
   (format-table df port #t #:keep-index? keep-index))

--- a/print.rkt
+++ b/print.rkt
@@ -63,12 +63,6 @@ All rights reserved.
 
 ;; ----------------------------------------------------
 
-(define (format-table-shape df port)
-  (let-values ([(rows cols) (table-shape df)])
-    (fprintf port "[~a rows x ~a cols]" rows cols)))
-
-;; ----------------------------------------------------
-
 (define (format-table df port mode #:keep-index? [keep-index #t])
   (let* ([repr (if mode ~v ~a)]
 
@@ -99,7 +93,7 @@ All rights reserved.
 
     ; output the shape of the table
     (newline port)
-    (format-table-shape df port)))
+    (table-preview-shape df port #f)))
 
 ;; ----------------------------------------------------
 

--- a/read.rkt
+++ b/read.rkt
@@ -169,6 +169,7 @@ All rights reserved.
                         #:double-quote? [double-quote #t]
                         #:comment-char [comment #\#]
                         #:strip? [strip #f]
+                        #:readers [readers (list string->number)]
                         #:na [na #f]
                         #:na-values [na-values (list "" "-" "." "na" "n/a" "nan" "null")])
   (let* ([spec `((separator-chars ,sep)
@@ -199,7 +200,7 @@ All rights reserved.
          ; parse cells, look for n/a as well
          [parse-row (λ (r)
                       (for/list ([x r])
-                        (let ([n (string->number x)])
+                        (let ([n (for/first [(f readers)] (f x))])
                           (cond
                             [n n]
                             [(member x na-values string-ci=?) na]

--- a/scribblings/tabular-asa.scrbl
+++ b/scribblings/tabular-asa.scrbl
@@ -139,6 +139,7 @@ It is important to note that - when reading tables - columns that don't already 
                          [#:double-quote? double-quote char? #t]
                          [#:comment-char comment char? #\#]
                          [#:strip? strip boolean? #f]
+                         [#:readers readers (listof function?) (list string->number)]
                          [#:na na any/c #f]
                          [#:na-values na-values (listof string?) (list "" "-" "." "na" "n/a" "nan" "null")])
          table?]{
@@ -146,9 +147,11 @@ It is important to note that - when reading tables - columns that don't already 
 
  The @racket[header] argument - if @racket[#t] - indicates that the first non-comment row of the CSV should be treated as the list of column names. If @racket[#f] then the column names will be generated as needed.
 
- The @racket[drop-index] arugment - if @racket[#t] - assumes that the first column of the CSV is the row index (i.e., an auto-incrementing integer) and shouldn't be kept. If there is a row index column, and it is not dropped, it's important to note that it will be treated just like any other column and is NOT used as the table's index.
-
+ The @racket[drop-index] argument - if @racket[#t] - assumes that the first column of the CSV is the row index (i.e., an auto-incrementing integer) and shouldn't be kept. If there is a row index column, and it is not dropped, it's important to note that it will be treated just like any other column and is NOT used as the table's index.
+ 
  The @racket[na-values] argument is a list of strings that - when parsed as the value for a given cell - are replaced with the @racket[na] value to indicate N/A (not available). The values in this list are case-insensitive.
+ 
+ The @racket[readers] argument - since CSVs are untyped, this is the list of type transforms that will be attempted on every cell, in order. The first one to successfully return a value will be the value in the cell. If none succeed, then the type of the cell is just a string. You can override this list to include functions from other packages like @racket[iso8601->date]. Similarly, you can supply an empty list to ensure all cells are either strings or the @racket[na] value. It should be noted that this list of transform readers is applied to all columns. In the future this may change to allow a @racket[hash], where each column can have its own list of transform readers.
 }
 
 @defproc[(table-read/json [port input-port?]

--- a/scribblings/tabular-asa.scrbl
+++ b/scribblings/tabular-asa.scrbl
@@ -264,7 +264,7 @@ Tables can also be built at constructed using an instance of @racket[table-build
 
   @verbatim|{#<table [359 rows x 8 cols]>}|
 
-  However, if you may supply your own function, or even replace it with @racket[display-table] or @racket[print-table] if you always want to see a preview of the table on the REPL.
+  However, if you may supply your own function, or even replace it with @racket[format-table] if you always want to see a preview of the table on the REPL.
 }
 
 @defproc[(table-length [df table?]) exact-nonnegative-integer?]{
@@ -522,10 +522,10 @@ Tables can also be built at constructed using an instance of @racket[table-build
   Controls the maximum number of rows output by @racket[write-table]. If set to @racket[#f] then there is no limit and all rows will be printed.
 }
 
-@defproc[(write-table [df table?]
-                      [port output-port? (current-output-port)]
-                      [mode boolean? #t]
-                      [#:keep-index? keep-index boolean? #t])
+@defproc[(format-table [df table?]
+                       [port output-port?]
+                       [mode boolean?]
+                       [#:keep-index? keep-index boolean? #t])
          void?]{
  Pretty prints a maximum of @racket[pretty-print-rows] rows of @racket[df] to @racket[port].
  If the table contains more rows than this, then the head and the tail of the table are output, and intermediate rows are elided.
@@ -539,14 +539,14 @@ Tables can also be built at constructed using an instance of @racket[table-build
                       [port output-port? (current-output-port)]
                       [#:keep-index? keep-index boolean? #t])
          void?]{
- Calls @racket[write-table] with the mode set to @racket[#t].
+ Calls @racket[format-table] with the mode set to @racket[#t].
 }
 
 @defproc[(display-table [df table?]
                         [port output-port? (current-output-port)]
                         [#:keep-index? keep-index boolean? #t])
          void?]{
- Calls @racket[write-table] with the mode set to @racket[#f].
+ Calls @racket[format-table] with the mode set to @racket[#f].
 }
 
 

--- a/scribblings/tabular-asa.scrbl
+++ b/scribblings/tabular-asa.scrbl
@@ -269,7 +269,7 @@ Tables can also be built at constructed using an instance of @racket[table-build
 
  @verbatim|{[359 rows x 8 cols]}|.
 
- If @racket[mode] is @racket[#t] then the shape is wrapped with @verbatim|{#<table ...>}|.
+ The @racket[mode] argument is currently ignored.
 }
 
 @defparam[table-preview proc (table? output-port? -> void?) #:value procedure?]{

--- a/scribblings/tabular-asa.scrbl
+++ b/scribblings/tabular-asa.scrbl
@@ -261,13 +261,21 @@ Tables can also be built at constructed using an instance of @racket[table-build
  An immutable, empty table. Useful for building a table from scratch using @racket[table-with-column] or returning from a function in failure cases, etc.
 }
 
+@defproc[(table-preview-shape [df table?]
+                              [port output-port?]
+                              [mode boolean?])
+         void?]{
+ Prints the shape of the table to the given port on a single line like so:
+
+ @verbatim|{[359 rows x 8 cols]}|.
+
+ If @racket[mode] is @racket[#t] then the shape is wrapped with @verbatim|{#<table ...>}|.
+}
 
 @defparam[table-preview proc (table? output-port? -> void?) #:value procedure?]{
-  Controls how tables are previewed on the REPL. The default function, simply prints the @racket[table-shape] on a single line like so:
+  Controls how tables are previewed on the REPL. The default function is @racket[table-preview-shape].
 
-  @verbatim|{#<table [359 rows x 8 cols]>}|
-
-  However, if you may supply your own function, or even replace it with @racket[format-table] if you always want to see a preview of the table on the REPL.
+  You may supply your own function, or even replace it with @racket[format-table] if you always want to see a preview of the table on the REPL.
 }
 
 @defproc[(table-length [df table?]) exact-nonnegative-integer?]{

--- a/table.rkt
+++ b/table.rkt
@@ -38,9 +38,7 @@ All rights reserved.
 
 (define (table-preview-shape df [port (current-output-port)] [mode #f])
   (let-values ([(rows cols) (table-shape df)])
-    (if mode
-        (fprintf port "#<table [~a rows x ~a cols]>" rows cols)
-        (fprintf port "[~a rows x ~a cols]" rows cols))))
+    (fprintf port "[~a rows x ~a cols]" rows cols)))
 
 ;; ----------------------------------------------------
 

--- a/table.rkt
+++ b/table.rkt
@@ -36,10 +36,15 @@ All rights reserved.
 
 ;; ----------------------------------------------------
 
-(define table-preview
-  (make-parameter (λ (df port mode)
-                    (let-values ([(rows cols) (table-shape df)])
-                      (fprintf port "#<table [~a rows x ~a cols]>" rows cols)))))
+(define (table-preview-shape df [port (current-output-port)] [mode #f])
+  (let-values ([(rows cols) (table-shape df)])
+    (if mode
+        (fprintf port "#<table [~a rows x ~a cols]>" rows cols)
+        (fprintf port "[~a rows x ~a cols]" rows cols))))
+
+;; ----------------------------------------------------
+
+(define table-preview (make-parameter table-preview-shape))
 
 ;; ----------------------------------------------------
 


### PR DESCRIPTION
* `table-read/csv` now accepts a `#:readers` argument
* Replaced `write-table` with `format-table` and it now takes the `mode` parameter
* Updated documentation for `table-preview`
* Separated out function `table-preview-shape` and documented it.

At this point, CSV reading should be more customizable as to the types elided and with printing, it should now be easier to work with the native `display` and `print` functions and restore the original preview as it's now a provided function.