### PR TITLE
export pretty-print-rows from main

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -132,6 +132,7 @@ All rights reserved.
  format-table
  display-table
  print-table
+ pretty-print-rows
 
  ; write
  table-write/csv


### PR DESCRIPTION
The parameter `pretty-print-rows` is documented, and defined by `print.rkt`, but `main` does not provide it. I'm guessing this is an oversight? This pull request adds `pretty-print-rows` to the list of names exported by `main.rkt`.